### PR TITLE
localized_extraction does not keep ids if executed with different parameters

### DIFF
--- a/localrec/__init__.py
+++ b/localrec/__init__.py
@@ -36,7 +36,7 @@ from localrec.convert import *
 
 getXmippPath = pwem.Domain.importFromPlugin("xmipp3.base", 'getXmippPath')
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 _logo = "localrec_logo.png"
 _references = ['Ilca2015', 'Abrishami2020']
 

--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -138,7 +138,7 @@ class ProtLocalizedExtraction(ProtParticles):
                 subpart = coord._subparticle
                 subpart.setLocation(
                     (i, outputStack))  # Change path to new stack
-                subpart.setObjId(None)  # Force to insert as a new item
+                subpart.setObjId(i)  # Ids will be always the same no mater the number of outliers 
                 outputSet.append(subpart)
 
         progress.finish()


### PR DESCRIPTION
Hi @JuhaHuiskonen 
 This pull request fixes the following problem.

1) Let us extract the sub-particles with a box of size S1 and process them
2) Now let us extract the same sub-particles but using a larger box (let us say size is S2 where S2 > S1)
3) Since the protocol localized_extraction   checks that the sub-particle  will not lay out of the original particle, what happens is that   if S2 > S1  the number of subparticles extracted using S2 will be equal or less than the number of
   particles extracted using S1
4) the protocol assigns correlative IDs to the sub-particles. So the same sub-particle may have different IDs  in the first and second extractions,  and therefore you cannot intersect both subsets or copy classifications/assignments from one set to the other

This pull request assigns the same IDs to the same particles no matter the size of the box.