### PR TITLE
Rmarabini patch 1

### DIFF
--- a/localrec/protocols/protocol_filter_subparticles.py
+++ b/localrec/protocols/protocol_filter_subparticles.py
@@ -36,6 +36,7 @@ from pwem.objects.data import SetOfParticles
 from localrec.utils import *
 # eventually progressbar will be move to scipion core
 from pyworkflow.utils import ProgressBar
+from pwem.objects import SetOfCoordinates
 
 
 class ProtFilterSubParts(ProtParticles):
@@ -45,6 +46,8 @@ class ProtFilterSubParts(ProtParticles):
     """
     _label = 'filter subparticles'
     _lastUpdateVersion = VERSION_3_0
+    OUTPUTCOORDINATESNAME = "outputCoordinates"
+    _possibleOutputs = {OUTPUTCOORDINATESNAME: SetOfCoordinates}
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
@@ -205,7 +208,7 @@ class ProtFilterSubParts(ProtParticles):
         self._genOutputCoordinates(subParticles, coordArr, outputSet,
                                    params["mindist"], params["keepRedundant"],
                                    params["distorigin"])
-        self._defineOutputs(outputCoordinates=outputSet)
+        self._defineOutputs(**{self.OUTPUTCOORDINATESNAME: outputSet})
         self._defineTransformRelation(self.inputSet, self.outputCoordinates)
 
     # -------------------------- INFO functions -------------------------------

--- a/localrec/protocols/protocol_localized.py
+++ b/localrec/protocols/protocol_localized.py
@@ -39,6 +39,7 @@ import pwem.emlib.metadata as md
 from localrec.utils import load_vectors, create_subparticles
 from localrec.constants import CMM, HAND
 from pyworkflow.utils import ProgressBar
+from pwem.objects import SetOfCoordinates
 
 
 class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
@@ -49,6 +50,8 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
     single particles.
     """
     _label = 'define subparticles'
+    OUTPUTCOORDINATESNAME = "outputCoordinates"
+    _possibleOutputs = {OUTPUTCOORDINATESNAME: SetOfCoordinates}
 
     def __init__(self, **args):
         ProtParticlePicking.__init__(self, **args)
@@ -222,7 +225,7 @@ class ProtLocalizedRecons(ProtParticlePicking, ProtParticles):
                     coord._subparticle.copyAttributes(part, '_rlnRandomSubset')
         progress.finish()
 
-        self._defineOutputs(outputCoordinates=outputSet)
+        self._defineOutputs(**{self.OUTPUTCOORDINATESNAME: outputSet})
         self._defineSourceRelation(self.inputParticles, outputSet)
 
     # -------------------------- INFO functions --------------------------------

--- a/localrec/protocols/protocol_localized_extraction.py
+++ b/localrec/protocols/protocol_localized_extraction.py
@@ -33,12 +33,15 @@ from pyworkflow.protocol.params import IntParam
 
 # eventually progressbar will be move to scipion core
 from pyworkflow.utils import ProgressBar
+from pwem.objects import SetOfParticles
 
 
 class ProtLocalizedExtraction(ProtParticles):
     """ Extract computed sub-particles from a SetOfParticles. """
     _label = 'extract subparticles'
     _lastUpdateVersion = VERSION_1_2
+    OUTPUTPARTICLESNAME = "outputParticles"
+    _possibleOutputs = {OUTPUTPARTICLESNAME: SetOfParticles}
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
@@ -146,7 +149,7 @@ class ProtLocalizedExtraction(ProtParticles):
             self.info("WARNING: Discarded %s particles because laid out of the "
                       "particle (for a box size of %d" % (outliers, boxSize))
 
-        self._defineOutputs(outputParticles=outputSet)
+        self._defineOutputs(**{self.OUTPUTPARTICLESNAME: outputSet})
         self._defineSourceRelation(self.inputParticles, outputSet)
 
     # -------------------------- INFO functions -------------------------------

--- a/localrec/protocols/protocol_localized_set_origin.py
+++ b/localrec/protocols/protocol_localized_set_origin.py
@@ -37,6 +37,7 @@ from os.path import basename
 from localrec.utils import vectors_from_string
 from localrec.constants import CMM
 from localrec.utils import load_vectors
+from pwem.objects import Volume
 
 
 class ProtLocalOrigSampling(EMProtocol):
@@ -46,9 +47,12 @@ class ProtLocalOrigSampling(EMProtocol):
     _label = 'Set origin to subvolume'
     _program = ""
     _lastUpdateVersion = VERSION_3_0
+    OUTPUTVOLUMENAME = "outputVolume"
+    _posibleOutputs = {OUTPUTVOLUMENAME: Volume}
 
     def __init__(self, **kwargs):
         EMProtocol.__init__(self, **kwargs)
+        
 
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):
@@ -155,7 +159,7 @@ class ProtLocalOrigSampling(EMProtocol):
         self.outVol.setLocation(imgDst)
 
         # save
-        self._defineOutputs(outputVolume=self.outVol)
+        self._defineOutputs(**{self.OUTPUTVOLUMENAME: self.outVol})
         self._defineSourceRelation(self.inVol, self.outVol)
 
     # --------------------------- INFO functions ------------------------------

--- a/localrec/protocols/protocol_localized_stitch.py
+++ b/localrec/protocols/protocol_localized_stitch.py
@@ -36,6 +36,7 @@ from pyworkflow.protocol.constants import STEPS_PARALLEL
 import pyworkflow.utils.path as putils
 
 from pwem import emlib
+from pwem.objects import Volume, SetOfVolumes
 
 from localrec.constants import CMM, LINEAR, symDict
 from localrec.utils import load_vectors
@@ -58,6 +59,10 @@ class ProtLocalizedStich(ProtPreprocessVolumes):
     def __init__(self, **kwargs):
         ProtPreprocessVolumes.__init__(self, **kwargs)
         self.stepsExecutionMode = STEPS_PARALLEL
+        OUTPUTVOLUMESNAME = "outputVolumes"
+        OUTPUTVOLUMENAME = "outputVolume"
+        _posibleOutputs = {OUTPUTVOLUMESNAME: SetOfVolumes,
+                            OUTPUTVOLUMENAME: Volume}
 
     #--------------------------- DEFINE param functions ------------------------
     def _defineParams(self, form):
@@ -147,7 +152,7 @@ class ProtLocalizedStich(ProtPreprocessVolumes):
         depsSymVolHalf2 = []
         depsSymVol = []
         depsSymMask = []
-
+        
         if self.usePreRun:
             localRecProt = self.preRuns[0].get()
             localRecSymGrp = localRecProt.symGrp.get()
@@ -445,7 +450,7 @@ class ProtLocalizedStich(ProtPreprocessVolumes):
                 outputVolFn = self._getOutputFileName(halfString)
                 outVol.setFileName(outputVolFn)
                 volumes.append(outVol)
-            self._defineOutputs(outputVolumes=volumes)
+            self._defineOutputs(**{self.OUTPUTVOLUMESNAME: volumes})
             self._defineSourceRelation(vol, volumes)
         else:
             vol = self.inputSubVolumes[0]
@@ -453,7 +458,7 @@ class ProtLocalizedStich(ProtPreprocessVolumes):
             outputVolFn = self._getOutputFileName()
             outVol.setSamplingRate(self.pxSize)
             outVol.setFileName(outputVolFn)
-            self._defineOutputs(outputVolume=outVol)
+            self._defineOutputs(**{self.OUTPUTVOLUMENAME: outVol})
             self._defineSourceRelation(vol,outVol)
 
     #--------------------------- INFO functions --------------------------------

--- a/localrec/protocols/protocol_localized_subset.py
+++ b/localrec/protocols/protocol_localized_subset.py
@@ -28,6 +28,7 @@
 from pyworkflow import VERSION_1_1
 from pyworkflow.protocol.params import PointerParam, FloatParam
 from pwem.protocols import ProtParticles
+from pwem.objects import SetOfParticles
 
 class ProtParticleSubset(ProtParticles):
     """ This protocol make a subset of particles for which there is at least
@@ -35,7 +36,9 @@ class ProtParticleSubset(ProtParticles):
     """
     _label = 'particles subset by subparticles'
     _lastUpdateVersion = VERSION_1_1
-
+    OUTPUTPARTICLESNAME = "outputParticles"
+    _possibleOutputs = {OUTPUTPARTICLESNAME: SetOfParticles}
+    
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
 
@@ -77,7 +80,7 @@ class ProtParticleSubset(ProtParticles):
             if particle._objId in subParticleIds:
                 outputSet.append(particle)
 
-        self._defineOutputs(outputParticles=outputSet)
+        self._defineOutputs(**{self.OUTPUTPARTICLESNAME: outputSet})
         self._defineTransformRelation(inputParticles, outputSet)
 
     # -------------------------- INFO functions -------------------------------

--- a/localrec/tests/test_protocol_localized_reconstruction.py
+++ b/localrec/tests/test_protocol_localized_reconstruction.py
@@ -219,13 +219,13 @@ class TestLocalizedRecons(TestLocalizedReconsBase):
 
         # Test for filter sub-particles which are aligned in the z
         localUniqueAligend = self._runFilterSubParticles(120, [149.0, 64.9, 73.2], localSubparticlesAligned, unique=5)
-        self._runFilterSubParticles(90, [149.0, 64.9, 73.2], localSubparticlesAligned, unique=5, mindist=10)
+        self._runFilterSubParticles(90, [149.0, 64.9, 73.2], localSubparticlesAligned, unique=5, mindist=6)
         self._runFilterSubParticles(50, [106.2, 112.6, -177.6], localSubparticlesAligned, unique=5, side=25)
         self._runFilterSubParticles(21, [47.6, 175.3, 159.1], localSubparticlesAligned, unique=5, top=50)
 
         # Test for filter sub-particles which are not aligned
         localUnique = self._runFilterSubParticles(120, [31.6, 60.155541, -138.80597], localSubparticles, unique=5)
-        self._runFilterSubParticles(90, [31.6, 60.155541, -138.80597], localSubparticles, unique=5, mindist=10)
+        self._runFilterSubParticles(90, [31.6, 60.155541, -138.80597], localSubparticles, unique=5, mindist=6)
         self._runFilterSubParticles(50, [103.2, 66.1, -66.9], localSubparticles, unique=5, side=25)
         self._runFilterSubParticles(21, [175.2, 66.1, -66.9], localSubparticles, unique=5, top=50)
 


### PR DESCRIPTION
Hi @JuhaHuiskonen ,

    This is a maintenance pull request. Traditionally, a workflow was created in scipion by assigning outputs of a protocol as inputs of another protocol. A limitation of this approach is that the outputs are only available once the protocol has been executed.
That is, a protocol is executed, then you add the next one etc.  Therefore, using the GUI, it is not possible to build a workflow before the needed inputs are generated. This pull request allows localrec to create "virtual outputs" that are generated BEFORE the protocol execution and may be used to create a workflow using the GUI without executing any protocol. That is, now is possible to create a new project, build the workflow and then lunch it.

