### PR TITLE
 randomize symmetry matrices

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,2 @@
-
-
+3.0.5
+    fix bug when option "randomize symmetry matrices..." is selected

--- a/localrec/__init__.py
+++ b/localrec/__init__.py
@@ -36,7 +36,7 @@ from localrec.convert import *
 
 getXmippPath = pwem.Domain.importFromPlugin("xmipp3.base", 'getXmippPath')
 
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 _logo = "localrec_logo.png"
 _references = ['Ilca2015', 'Abrishami2020']
 

--- a/localrec/utils.py
+++ b/localrec/utils.py
@@ -311,7 +311,7 @@ def create_subparticles(particle, symmetry_matrices, subparticle_vector_list,
 
     subparticles = []
     subparticles_total += 1
-    symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)
+    symmetry_matrix_ids = list(range(1, len(symmetry_matrices) + 1))
 
     if randomize:
         # randomize the order of symmetry matrices, prevents preferred views


### PR DESCRIPTION
In protocol localrec-define-subparticles the option "randomize the order of..." does not work. The problem seems to be in line

    symmetry_matrix_ids = range(1, len(symmetry_matrices) + 1)

since later symmetry_matrix_ids it is assumed to be a list. The following modification fixes this problem:

    symmetry_matrix_ids = list(range(1, len(symmetry_matrices) + 1)

I guess this bug is a side effect of the python2-> python3 migration since in Python-3.x, range(..) no longer produces a list, it produces a range object.